### PR TITLE
Fix schema matching

### DIFF
--- a/Json Schema/src/main/resources/schemas/custom_machinery_recipe.json
+++ b/Json Schema/src/main/resources/schemas/custom_machinery_recipe.json
@@ -4,7 +4,12 @@
   "allOf": [
     {
       "if": {
-        "required": ["output"]
+        "properties": {
+          "type": {
+            "enum": ["custommachinery:custom_craft"],
+            "required": true
+          }
+        }
       },
       "then": {
         "$ref": "https://alec016.github.io/Custom-Machinery/Json%20Schema/src/main/resources/schemas/craft_recipe.json"
@@ -12,7 +17,12 @@
     },
     {
       "if": {
-        "required": ["time"]
+        "properties": {
+          "type": {
+            "enum": ["custommachinery:custom_machine"],
+            "required": true
+          }
+        }
       },
       "then": {
         "$ref": "https://alec016.github.io/Custom-Machinery/Json%20Schema/src/main/resources/schemas/machine_recipe.json"


### PR DESCRIPTION
The Schema you've added to schemastore 4 days ago matches all recipes that have either an output or a time value. this is just not really nice to work with when you have any kind of other recipe that has that value as stuff like immersive engineerings garden cloches are now validated against your custom machine schema, because it has a time property.
This PR fixes this by matching against the schema if the recipetype is set correctly 